### PR TITLE
Add weather service feature for city searches

### DIFF
--- a/ShopTARge23/ShopTARge23.ApplicationServices/Services/OpenWeatherServices.cs
+++ b/ShopTARge23/ShopTARge23.ApplicationServices/Services/OpenWeatherServices.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using System.Text.Json;
+using ShopTARge23.Core.Dto.WeatherDtos.OpenWeatherDtos;
+using ShopTARge23.Core.ServiceInterface;
+
+namespace ShopTARge23.ApplicationServices.Services
+{
+    public class OpenWeatherServices : IOpenWeatherServices
+    {
+        public async Task<OpenWeatherResultDto> GetOpenWeatherResult(OpenWeatherResultDto dto)
+        {
+            string apiKey = "fd0363eff9b6561f4c3c8385b5be3b3c"; // Lisa oma API võti siia
+            string url = $"https://api.openweathermap.org/data/2.5/weather?q={dto.CityName}&appid={apiKey}&units=metric";
+
+            using (WebClient client = new WebClient())
+            {
+                string json = client.DownloadString(url);
+                OpenWeatherRootDto weatherResult = JsonSerializer.Deserialize<OpenWeatherRootDto>(json);
+
+                dto.CityName = weatherResult.Name;
+                dto.Temperature = weatherResult.Main.Temp;
+                dto.Description = weatherResult.Weather[0].Description;
+                dto.WeatherMain = weatherResult.Weather[0].Main;
+                dto.FeelsLike = weatherResult.Main.FeelsLike;
+                dto.TempMin = weatherResult.Main.TempMin;
+                dto.TempMax = weatherResult.Main.TempMax;
+                dto.Humidity = weatherResult.Main.Humidity;
+                dto.Pressure = weatherResult.Main.Pressure;
+                dto.WindSpeed = weatherResult.Wind.Speed;
+                dto.WindDeg = weatherResult.Wind.Deg;
+                dto.Cloudiness = weatherResult.Clouds.All;
+                dto.Icon = weatherResult.Weather[0].Icon;
+            }
+
+            return dto;
+        }
+    }
+}

--- a/ShopTARge23/ShopTARge23.Core/Dto/OpenWeatherDtos/OpenWeatherResultDto.cs
+++ b/ShopTARge23/ShopTARge23.Core/Dto/OpenWeatherDtos/OpenWeatherResultDto.cs
@@ -1,0 +1,19 @@
+﻿namespace ShopTARge23.Core.Dto.WeatherDtos.OpenWeatherDtos
+{
+    public class OpenWeatherResultDto
+    {
+        public string CityName { get; set; }
+        public double Temperature { get; set; }
+        public string Description { get; set; }
+        public string WeatherMain { get; set; }
+        public double FeelsLike { get; set; }
+        public double TempMin { get; set; }
+        public double TempMax { get; set; }
+        public int Humidity { get; set; }
+        public int Pressure { get; set; }
+        public double WindSpeed { get; set; }
+        public int WindDeg { get; set; }
+        public int Cloudiness { get; set; }
+        public string Icon { get; set; }
+    }
+}

--- a/ShopTARge23/ShopTARge23.Core/Dto/OpenWeatherDtos/OpenWeatherRootDto.cs
+++ b/ShopTARge23/ShopTARge23.Core/Dto/OpenWeatherDtos/OpenWeatherRootDto.cs
@@ -1,0 +1,88 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ShopTARge23.Core.Dto.WeatherDtos.OpenWeatherDtos
+{
+    public class OpenWeatherRootDto
+    {
+        [JsonPropertyName("coord")]
+        public CoordDto Coord { get; set; }
+
+        [JsonPropertyName("weather")]
+        public List<WeatherDto> Weather { get; set; }
+
+        [JsonPropertyName("main")]
+        public MainDto Main { get; set; }
+
+        [JsonPropertyName("wind")]
+        public WindDto Wind { get; set; }
+
+        [JsonPropertyName("clouds")]
+        public CloudsDto Clouds { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("cod")]
+        public int Cod { get; set; }
+    }
+
+    public class CoordDto
+    {
+        [JsonPropertyName("lon")]
+        public double Lon { get; set; }
+
+        [JsonPropertyName("lat")]
+        public double Lat { get; set; }
+    }
+
+    public class WeatherDto
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("main")]
+        public string Main { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("icon")]
+        public string Icon { get; set; }
+    }
+
+    public class MainDto
+    {
+        [JsonPropertyName("temp")]
+        public double Temp { get; set; }
+
+        [JsonPropertyName("feels_like")]
+        public double FeelsLike { get; set; }
+
+        [JsonPropertyName("temp_min")]
+        public double TempMin { get; set; }
+
+        [JsonPropertyName("temp_max")]
+        public double TempMax { get; set; }
+
+        [JsonPropertyName("pressure")]
+        public int Pressure { get; set; }
+
+        [JsonPropertyName("humidity")]
+        public int Humidity { get; set; }
+    }
+
+    public class WindDto
+    {
+        [JsonPropertyName("speed")]
+        public double Speed { get; set; }
+
+        [JsonPropertyName("deg")]
+        public int Deg { get; set; }
+    }
+
+    public class CloudsDto
+    {
+        [JsonPropertyName("all")]
+        public int All { get; set; }
+    }
+}

--- a/ShopTARge23/ShopTARge23.Core/ServiceInterface/IOpenWeatherServices.cs
+++ b/ShopTARge23/ShopTARge23.Core/ServiceInterface/IOpenWeatherServices.cs
@@ -1,0 +1,9 @@
+﻿using ShopTARge23.Core.Dto.WeatherDtos.OpenWeatherDtos;
+
+namespace ShopTARge23.Core.ServiceInterface
+{
+    public interface IOpenWeatherServices
+    {
+        Task<OpenWeatherResultDto> GetOpenWeatherResult(OpenWeatherResultDto dto);
+    }
+}


### PR DESCRIPTION
This commit introduces a new weather service to the ShopTARge23 application, enabling users to search for weather information by city. Key changes include:

- Creation of `OpenWeatherServices` to interact with the OpenWeather API.
- Addition of `OpenWeatherResultDto` and `OpenWeatherRootDto` for structured API data.
- Definition of `IOpenWeatherServices` interface for service abstraction.
- Updates to `OpenWeathersController` for handling weather data requests.
- Introduction of new view models: `OpenWeatherSearchViewModel` and `OpenWeatherViewModel`.
- Modifications to views (`Index.cshtml`, `City.cshtml`, `_Layout.cshtml`) for user input and display of weather data.
- Configuration of dependency injection in `Program.cs` for the new service.